### PR TITLE
updated the links in our org

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -21,10 +21,11 @@ Pedagogical foundations
 
 ### Foundations
 
-- [`Shell, Git and GitHub`](https://github.com/UofT-DSI/01-shell_git_github)
+- [`Shell`](https://github.com/UofT-DSI/shell)
+- [`Git`](https://github.com/UofT-DSI/git)
 - [`SQL`](https://github.com/UofT-DSI/02-sql)
-- [`Python`](https://github.com/UofT-DSI/03-python)
-- [`R`](https://github.com/UofT-DSI/04-r)
+- [`Python`](https://github.com/UofT-DSI/python)
+- [`R`](https://github.com/UofT-DSI/r)
 
 ### Software engineering
 


### PR DESCRIPTION
A collective decision made to rename some of the repos for the sake of simplicity. Only the repos that are currently not being used by learners have been updated, but essentially all names should get rid of numbers in their names and to be as simple as possible.

As of right now, only R, Python, Git and Shell repos have been updated.